### PR TITLE
Update README to remove GitHub flavored Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ A project based learning activity for people who are getting started with Git an
 
 You can play the game at: https://githubschool.github.io/github-games/
 
-> [!IMPORTANT]
-> **SUPPORTED BROWSERS**: Chrome, Firefox, Safari, and Opera
+>> **SUPPORTED BROWSERS**: Chrome, Firefox, Safari, and Opera
 
 This fun open source game was cloned from: https://github.com/jakesgordon/javascript-tetris


### PR DESCRIPTION
Reset README because GH Pages doesn't support GH-flavored Markdown, particularly [alerts](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts).